### PR TITLE
respect the CLOUD_CONTROLLER_CONFIG environment variable

### DIFF
--- a/common/util.rb
+++ b/common/util.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'vcap/common'
 require 'yaml'
 
-CC_CONFIG_FILE = File.expand_path("../../../cloud_controller/config/cloud_controller.yml", __FILE__)
+CC_CONFIG_FILE = ENV['CLOUD_CONTROLLER_CONFIG'] || File.expand_path("../../../cloud_controller/config/cloud_controller.yml", __FILE__)
 
 def default_cloud_controller_uri
   puts CC_CONFIG_FILE


### PR DESCRIPTION
This change is required if one is to use a custom cloud controller config file, especially to use a real domain instead of api.vcap.me.
