### PR TITLE
Role-specific cloud_controller.yml files + custom domain names

### DIFF
--- a/common/util.rb
+++ b/common/util.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'vcap/common'
 require 'yaml'
 
-CC_CONFIG_FILE = File.expand_path("../../../cloud_controller/config/cloud_controller.yml", __FILE__)
+CC_CONFIG_FILE = ENV['CLOUD_CONTROLLER_CONFIG'] || File.expand_path("../../../cloud_controller/config/cloud_controller.yml", __FILE__)
 
 def default_cloud_controller_uri
   puts CC_CONFIG_FILE


### PR DESCRIPTION
When using a custom domain name (api.myveryownfoundry.com), services incorrectly look up api.vcap.me to access the cloud_controller. To fix this, the cloud_controller.yml file should be updated. This proposed change allows to specify the cloud_controller.yml file path in an environment variable. Also, this would enable config file switching depending on the server role (dev, staging, production, etc).
