### PR TITLE
Add cache directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ci-working-dir
 *.rbc
 *.swp
 .rvmrc
+*/vendor/cache/*.*
+


### PR DESCRIPTION
This adds _/vendor/cache/_.\* to .gitignore so those files are not accidentally committed.
