### PR TITLE
Proxy support for vcap-services

### DIFF
--- a/base/lib/base/gateway.rb
+++ b/base/lib/base/gateway.rb
@@ -85,6 +85,7 @@ class VCAP::Services::Base::Gateway
              :allow_over_provisioning => config[:allow_over_provisioning]
            )
       sg = VCAP::Services::AsynchronousServiceGateway.new(
+             :proxy => config[:proxy],
              :service => config[:service],
              :token   => config[:token],
              :logger  => logger,

--- a/mongodb/config/mongodb_gateway.yml
+++ b/mongodb/config/mongodb_gateway.yml
@@ -6,6 +6,10 @@ service:
   description: 'MongoDB NoSQL store'
   plans: ['free']
   tags: ['mongodb', 'mongodb-1.6', 'nosql']
+#proxy:
+#   host: proxy
+#   port: 8080
+#   keepalive: true
 host: localhost
 index: 0
 token: "0xdeadbeef"

--- a/mysql/config/mysql_gateway.yml
+++ b/mysql/config/mysql_gateway.yml
@@ -6,6 +6,10 @@ service:
   description: 'MySQL database service'
   plans: ['free']
   tags: ['mysql', 'mysql-5.1', 'relational']
+#proxy:
+#   host: proxy
+#   port: 8080
+#   keepalive: true
 host: localhost
 index: 0
 token: "0xdeadbeef"

--- a/postgresql/config/postgresql_gateway.yml
+++ b/postgresql/config/postgresql_gateway.yml
@@ -6,6 +6,10 @@ service:
   description: 'PostgreSQL database service'
   plans: ['free']
   tags: ['postgresql', 'postgresql-9.0', 'relational']
+#proxy:
+#   host: proxy
+#   port: 8080
+#   keepalive: true
 host: localhost
 token: "0xdeadbeef"
 log_level: DEBUG

--- a/rabbit/config/rabbit_gateway.yml
+++ b/rabbit/config/rabbit_gateway.yml
@@ -6,6 +6,10 @@ service:
   description: 'RabbitMQ message queue'
   plans: ['free']
   tags: ['rabbitmq', 'rabitmq-2.4', 'message-queue', 'amqp']
+#proxy:
+#   host: proxy
+#   port: 8080
+#   keepalive: true
 host: localhost
 index: 0
 token: "0xdeadbeef"

--- a/redis/config/redis_gateway.yml
+++ b/redis/config/redis_gateway.yml
@@ -6,6 +6,10 @@ service:
   description: 'Redis key-value store service'
   plans: ['free']
   tags: ['redis', 'redis-2.2', 'key-value', 'nosql']
+#proxy:
+#   host: proxy
+#   port: 8080
+#   keepalive: true
 host: localhost
 index: 0
 token: "0xdeadbeef"


### PR DESCRIPTION
add proxy support to vcap-services so that services can communicate with cloud controller via proxy
