### PR TITLE
Updated MongoDB tag from 1.6 to 1.8.

### DIFF
--- a/mongodb/config/mongodb_gateway.yml
+++ b/mongodb/config/mongodb_gateway.yml
@@ -5,7 +5,7 @@ service:
   version: "1.8"
   description: 'MongoDB NoSQL store'
   plans: ['free']
-  tags: ['mongodb', 'mongodb-1.6', 'nosql']
+  tags: ['mongodb', 'mongodb-1.8', 'nosql']
 ip_route: localhost
 #proxy:
 #   host: proxy


### PR DESCRIPTION
The version attribute was correctly set to 1.8, but the tag was still marked as 1.6.
