### PR TITLE
pass port, username and password to status Thin server

### DIFF
--- a/base/lib/base/base.rb
+++ b/base/lib/base/base.rb
@@ -35,12 +35,21 @@ class VCAP::Services::Base::Base
     @node_nats = NATS.connect(:uri => options[:mbus]) {
       on_connect_node
     }
+    status_port = status_username = status_password = nil
+    if not options[:status].nil?
+        status_port = options[:status][:port]
+        status_username = options[:status][:username]
+        status_password = options[:status][:password]
+    end
     VCAP::Component.register(
       :nats => @node_nats,
       :type => service_description,
       :host => @local_ip,
       :index => options[:index] || 0,
-      :config => options
+      :config => options,
+      :port => status_port,
+      :username => status_username,
+      :password => status_password
     )
     z_interval = options[:z_interval] || 30
     EM.add_timer(5) { update_varz } # give service a chance to wake up

--- a/base/lib/base/gateway.rb
+++ b/base/lib/base/gateway.rb
@@ -69,7 +69,7 @@ class VCAP::Services::Base::Gateway
     config[:service][:label] = "#{config[:service][:name]}-#{config[:service][:version]}"
     config[:service][:url]   = "http://#{config[:host]}:#{config[:port]}"
     cloud_controller_uri = config[:cloud_controller_uri] || default_cloud_controller_uri
-
+    
     # Go!
     EM.run do
       sp = provisioner_class.new(
@@ -79,7 +79,8 @@ class VCAP::Services::Base::Gateway
              :ip_route => config[:ip_route],
              :mbus => config[:mbus],
              :node_timeout => config[:node_timeout] || 2,
-             :allow_over_provisioning => config[:allow_over_provisioning]
+             :allow_over_provisioning => config[:allow_over_provisioning],
+             :status => config[:status]
            )
       sg = VCAP::Services::AsynchronousServiceGateway.new(
              :proxy => config[:proxy],


### PR DESCRIPTION
Find status entry in config and pass it to Component, so healthz server is
started on desired port with specified credentials. Yaml config entry should look
like
--- yaml ---
status:
  port: 3333
  username: admin
  password: admin
--- yaml ---
