### PR TITLE
configuration format improvement

### DIFF
--- a/base/lib/base/base.rb
+++ b/base/lib/base/base.rb
@@ -48,7 +48,7 @@ class VCAP::Services::Base::Base
     status_port = status_username = status_password = nil
     if not options[:status].nil?
         status_port = options[:status][:port]
-        status_username = options[:status][:username]
+        status_username = options[:status][:user]
         status_password = options[:status][:password]
     end
     VCAP::Component.register(

--- a/base/lib/base/base.rb
+++ b/base/lib/base/base.rb
@@ -48,7 +48,7 @@ class VCAP::Services::Base::Base
     status_port = status_username = status_password = nil
     if not options[:status].nil?
         status_port = options[:status][:port]
-        status_username = options[:status][:user]
+        status_user = options[:status][:user]
         status_password = options[:status][:password]
     end
     VCAP::Component.register(
@@ -58,7 +58,7 @@ class VCAP::Services::Base::Base
       :index => options[:index] || 0,
       :config => options,
       :port => status_port,
-      :username => status_username,
+      :user => status_user,
       :password => status_password
     )
 


### PR DESCRIPTION
I found cloudfoundry/vcap components use 'port'/'user'/'password' for status server configuration,whereas cloudfoundry/vcap-services use 'port'/'username'/'password'.

It does not matter which to use 'user' or 'username' but it would be better to use the same format to reduce configuration errors.
 # I think 'username' would be better but all vcap components already use 'user' as the name, which I took in

Thanks.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
