### PR TITLE
[services-ng] fix bug of connect_timeout in pg_timeout

### DIFF
--- a/ng/postgresql/lib/postgresql_service/pg_timeout.rb
+++ b/ng/postgresql/lib/postgresql_service/pg_timeout.rb
@@ -8,7 +8,6 @@ module VCAP
       module Util
 
         class DBconn
-          attr_accessor :connect_timeout
           attr_accessor :query_timeout
           attr_accessor :conn_mutex
           attr_accessor :transaction_tid_mutex
@@ -51,7 +50,7 @@ module VCAP
           end
 
           def initialize(conn_opts)
-            @connect_timeout = conn_opts[:connect_timeout] || self.class.default_connect_timeout
+            conn_opts[:connect_timeout] ||= self.class.default_connect_timeout
             @query_timeout = conn_opts[:query_timeout] || self.class.default_query_timeout
             valid_conn_opts = self.class.validate_conn_opts(conn_opts)
             @conn, @conn_io_socket = async? ? self.class.async_connect(valid_conn_opts) : self.class.connect(valid_conn_opts)

--- a/ng/postgresql/lib/postgresql_service/util.rb
+++ b/ng/postgresql/lib/postgresql_service/util.rb
@@ -72,7 +72,6 @@ module VCAP
             :try_num => 1,
             :exception_sleep => 0,
             :quiet => true,
-            :async => true
           ) if quick_mode
 
           fail_with_nil = opts[:fail_with_nil] || true
@@ -80,7 +79,6 @@ module VCAP
           try_num = opts[:try_num] || 5
           exception_sleep = opts[:exception_sleep] || 1
           quiet = opts[:quiet] || false
-          async = opts[:async] || true
 
           @logger ||= Logger.new(STDOUT)
           conn_opts = {

--- a/ng/postgresql/spec/postgresql_node_spec.rb
+++ b/ng/postgresql/spec/postgresql_node_spec.rb
@@ -71,6 +71,63 @@ describe "Postgresql node normal cases" do
     end
   end
 
+  it "should add timeout to connect" do
+    pending "Not to use warden, won't run this case." unless @opts[:use_warden]
+    pending "Not to use async methods, won't run this case." unless @opts[:db_use_async_query]
+    EM.run do
+      default_connect_timeout = VCAP::Services::Postgresql::Util::PGDBconn.default_connect_timeout
+
+      tmp_db = @node.provision(@default_plan, nil, @default_version)
+      tmp_instance = @node.pgProvisionedService.get(tmp_db['name'])
+      @test_dbs[tmp_db] = []
+
+      expect { connect_to_postgresql(tmp_db).close }.should_not raise_error
+
+      begin
+        # simulate the select timeout issue
+        class IO
+          class << self
+            alias_method :select_ori, :select
+            def select(read_array, write_array, error_array, timeout)
+              if timeout
+                # block thread for specifid time
+                sleep timeout
+              else
+                # block thread for ever (180 seconds is long enough for test)
+                sleep 180
+              end
+              raise PGError, "simulated select timeout"
+            end
+          end
+        end
+
+        # use default connect_timeout
+        start_time = Time.now.to_f
+        expect { conn = connect_to_postgresql(tmp_db) }.should raise_error(PGError, /simulated select timeout/)
+        connect_time = Time.now.to_f - start_time
+        connect_time.should >= default_connect_timeout
+        connect_time.should < (default_connect_timeout + 1)
+
+        # use specified connect_timeout
+        start_time = Time.now.to_f
+        expect { conn = connect_to_postgresql(tmp_db, :connect_timeout => (default_connect_timeout + 2))}.should raise_error(PGError, /simulated select timeout/)
+        connect_time = Time.now.to_f - start_time
+        connect_time >= default_connect_timeout + 2
+        connect_time.should < (default_connect_timeout + 3)
+
+      ensure
+        # restore the IO.select method
+        class IO
+          class << self
+            alias_method :select, :select_ori
+          end
+        end
+      end
+
+      EM.stop
+    end
+  end
+
   it "should add timeout to query" do
     EM.run do
       ori_default_query_timeout = VCAP::Services::Postgresql::Util::PGDBconn.default_query_timeout
@@ -1071,8 +1128,7 @@ describe "Postgresql node special cases" do
     db = node.provision(@default_plan, nil, @default_version)
     conn = connect_to_postgresql(db)
     expect { conn.query("SELECT 1") }.should_not raise_error
-    expect { connect_to_postgresql(db, :async => false ) }.should raise_error(PGError, /too many connections for database .*/)
-    expect { connect_to_postgresql(db, :async => true) }.should raise_error
+    expect { connect_to_postgresql(db) }.should raise_error(PGError, /too many connections for database .*/)
     conn.close if conn
     node.unprovision(db["name"], [])
   end


### PR DESCRIPTION
When there is no connect_timeout in conn_opts, we should use the default value.

Add a new unit test case for connect_timeout

Unit-test passed: warden/non-warden
Yeti-test passed: plan 100/200

Change-Id: I6272b2d42103e93ab8a31ebf9926b91acaf96783
