### PR TITLE
Fix mongodb node bug

### DIFF
--- a/ng/mongodb/lib/mongodb_service/mongodb_node.rb
+++ b/ng/mongodb/lib/mongodb_service/mongodb_node.rb
@@ -535,6 +535,7 @@ class VCAP::Services::MongoDB::Node::ProvisionedService
   end
 
   def finish_start?
+    conn = nil
     Timeout::timeout(MONGO_TIMEOUT) do
       conn = Mongo::Connection.new(ip, SERVICE_PORT)
       auth = conn.db("admin").authenticate(admin, adminpass)
@@ -543,15 +544,20 @@ class VCAP::Services::MongoDB::Node::ProvisionedService
     true
   rescue => e
     false
+  ensure
+    conn.close unless conn.nil?
   end
 
   def finish_first_start?
+    conn = nil
     Timeout::timeout(MONGO_TIMEOUT) do
       conn = Mongo::Connection.new(ip, SERVICE_PORT)
     end
     true
   rescue => e
     false
+  ensure
+    conn.close unless conn.nil?
   end
 
   def add_user(username, password)


### PR DESCRIPTION
release connection when it is unused. service instances monitor calls finish_start? periodically, if connection not released then mongodb instance connection number shall increase dramatically, and finally exceeds 'maxConn', afterwards, clients will never connect to mongodb instance.
