### PR TITLE
[services-ng] add xlog enforcement for postgresql service

### DIFF
--- a/ng/postgresql/bin/postgresql_node
+++ b/ng/postgresql/bin/postgresql_node
@@ -25,6 +25,8 @@ class VCAP::Services::Postgresql::NodeBin < VCAP::Services::Base::NodeBin
     options[:max_long_tx] = parse_property(config, "max_long_tx", Integer)
     options[:postgresql] = parse_property(config, "postgresql", Hash)
     options[:max_db_conns] = parse_property(config, "max_db_conns", Integer)
+    options[:enable_xlog_enforcer] = parse_property(config, "enable_xlog_enforcer", Boolean, :optional => true, :default => false)
+    options[:xlog_enforce_tolerance] = parse_property(config, "xlog_enforce_tolerance", Integer, :optional => true, :default => 5)
     options[:use_warden] = parse_property(config, "use_warden", Boolean, :optional => true, :default => false)
     options[:supported_versions] = parse_property(config, "supported_versions", Array)
     options[:default_version] = parse_property(config, "default_version", String)

--- a/ng/postgresql/config/postgresql_node.yml
+++ b/ng/postgresql/config/postgresql_node.yml
@@ -15,6 +15,8 @@ max_db_size: 30
 max_long_query: 3
 max_long_tx: 30
 max_db_conns: 20
+enable_xlog_enforcer: true
+xlog_enforce_tolerance: 5
 db_connect_timeout: 3
 db_query_timeout: 10
 db_use_async_query: true

--- a/ng/postgresql/lib/postgresql_service/model.rb
+++ b/ng/postgresql/lib/postgresql_service/model.rb
@@ -66,7 +66,14 @@ module VCAP
             def init(args)
               super(args)
               @@postgresql_config  = args[:postgresql]
+              @@xlog_enforce_tolerance  = args[:xlog_enforce_tolerance] || 5
             end
+          end
+
+          define_im_properties :xlog_tolerant_times
+
+          def xlog_tolerant?
+            !xlog_tolerant_times || xlog_tolerant_times <= @@xlog_enforce_tolerance
           end
 
           def default_user

--- a/ng/postgresql/lib/postgresql_service/pg_timeout.rb
+++ b/ng/postgresql/lib/postgresql_service/pg_timeout.rb
@@ -125,6 +125,10 @@ module VCAP
             end
           end
 
+          def settings
+            @db_settings ||= {}
+          end
+
           def close
             @conn_io_socket.close if @conn_io_socket && !@conn_io_socket.closed?
             @conn.close
@@ -177,6 +181,13 @@ module VCAP
               raise e
             end
 
+          end
+
+          def settings
+            @db_settings ||= query("select name, setting from pg_settings").inject({}) do |h, r|
+              h[r['name']] = r['setting']
+              h
+            end
           end
         end
 

--- a/ng/postgresql/lib/postgresql_service/xlog_enforce.rb
+++ b/ng/postgresql/lib/postgresql_service/xlog_enforce.rb
@@ -1,0 +1,66 @@
+# Copyright (c) 2009 - 2013 VMware, Inc.
+require "pg_timeout"
+require "util"
+
+module VCAP; module Services; module Postgresql; end; end; end
+
+class VCAP::Services::Postgresql::Node
+
+  XLOG_STATUS_OK = 0
+  XLOG_STATUS_CHK = 1
+  XLOG_STATUS_KILL = 2
+
+  # Limitation of xlog file number when you are sensitive to the storage capacity
+  # Due to a short-term peak of log output rate, there are more than 3 * checkpoint_segments + 1 segment files
+  # the unneeded segment files will be deleted instead of recycled until the system gets back under this limit
+  # or below the value, checkpoint (force/xlog/timeout) will just recycle them
+  def xlog_file_checkpoint_limit(conn)
+    conn.settings['checkpoint_segments'].to_i * 3 + 2
+  end
+
+  # Limitation of xlog file number when you are snesitive to the storage capacity
+  # If we find the xlog file number exceeds this limitation in a continous (xlog_enforce_tolerance) check
+  # We will try to kill the open connections and run a checkpoint
+  def xlog_file_kill_limit(conn)
+    conn.settings['checkpoint_segments'].to_i * 4 + 2
+  end
+
+  def xlog_file_num(data_dir)
+    raise "Fail to locate the PGDATA" unless File.directory?(data_dir)
+    Dir.glob(File.join(data_dir, 'pg_xlog', '*')).select { |f| File.file?(f) }.count
+  end
+
+  def xlog_status(conn, data_dir)
+    file_num = xlog_file_num(data_dir)
+    return XLOG_STATUS_KILL if file_num > xlog_file_kill_limit(conn)
+    return XLOG_STATUS_CHK  if file_num >= xlog_file_checkpoint_limit(conn)
+    return XLOG_STATUS_OK
+  end
+
+  # Use this method to enforce xlog file number
+  # Usually, xlog file number are limited by checkpoint_segmentations parameters
+  # http://www.postgresql.org/docs/9.2/static/wal-configuration.html
+  # We will monitor this
+  #  * A alert must be issued if exceeding CHECKPOINT limit
+  #  * A force checkpoint is executed if exceeding CHECKPOINT limit
+  #  * All open connections will be terminated only if exceeding KILL limit
+  # This enforcement might lead to worse user experience, but considering we provide enough xlog file number quota and enable long-time tx killer
+  # exceeding the number limitaions is rare and usually a hint of attacks or faulty configurations
+  # Note: xlog enforcement might hurt performance, so make a trade-off on performance and storage overhead for xlog files
+  def xlog_enforce_internal(conn, opts={})
+    cur_xlog_status = opts[:xlog_status] || XLOG_STATUS_OK
+    return if cur_xlog_status == XLOG_STATUS_OK
+    @logger ||= create_logger
+    @logger.warn("Alert: exceeding the xlog in server #{conn.host}:#{conn.port}")
+    unless opts[:alert_only] || false
+      if cur_xlog_status == XLOG_STATUS_KILL
+        @logger.warn("Terminate alive binding users' connections")
+        excluded_users = opts[:excluded_users] || []
+        excluded_users += [conn.user]
+        kill_alive_sessions(conn, :mode => 'exclude', :users => excluded_users)
+      end
+      @logger.warn("Issue a force checkpoint for xlog exceeding")
+      conn.query("CHECKPOINT")
+    end
+  end
+end


### PR DESCRIPTION
1. Add a periodical timer to check the xlog file number, interval is 1 second
   - non-wardenized case: only write a warnning in the log
   - wardenized case:
     1) if xlog_file_num in [ 3 \* checkpoint_segments + 2, 4_checkpoint_segments + 2), 
         issue a force checkpoint, try to delete unneeded segment files
     2) if xlog_file_num in [ 4_checkpoint_segments + 2, ~) after a continous 5 (xlog_enforce_tolerance) times check, 
         terminate the connections from applications (won't terminate the super user and default users)
   - note:
     - only for oss postgresql (checkpoint_segments_max is not provided.) and plans which  
       are sensitive to storage overhead for xlog files
     - this is a trade-off of performance and storage
     - provide more storage for xlog is preferred.
     - this enforcer could be disabled
     - xlog_enforce_tolerance could be tuned.
2. Varz will include the xlog file number information
