### PR TITLE
[services-ng] change example config files to support postgresql 9.2

### DIFF
--- a/ng/postgresql/config/postgresql_backup.yml
+++ b/ng/postgresql/config/postgresql_backup.yml
@@ -20,6 +20,13 @@ postgresql:
     pass: vcap
     database: postgres
     dump_bin: /var/vcap/packages/postgresql91/bin/pg_dump
+  '9.2':
+    host: localhost
+    port: 5434
+    user: vcap
+    pass: vcap
+    database: postgres
+    dump_bin: /var/vcap/packages/postgresql92/bin/pg_dump
 logging:
   level: debug
 pid: /var/vcap/sys/run/postgresql_backup.pid

--- a/ng/postgresql/config/postgresql_node.yml
+++ b/ng/postgresql/config/postgresql_node.yml
@@ -60,7 +60,7 @@ postgresql:
     restore_bin: /var/vcap/packages/postgresql92/bin/pg_restore
     dump_bin: /var/vcap/packages/postgresql92/bin/pg_dump
 supported_versions: ['9.0', '9.1', '9.2']
-default_version: '9.1'
+default_version: '9.2'
 
 # z_interval: 30
 # fqdn_hosts: false

--- a/ng/postgresql/config/postgresql_worker.yml
+++ b/ng/postgresql/config/postgresql_worker.yml
@@ -28,4 +28,20 @@ postgresql:
     database: postgres
     restore_bin: pg_restore
     dump_bin: pg_dump
+  '9.1':
+    host: 127.0.0.1
+    port: 5433
+    user: vcap
+    pass: vcap
+    database: postgres
+    restore_bin: pg_restore
+    dump_bin: pg_dump
+  '9.2':
+    host: 127.0.0.1
+    port: 5434
+    user: vcap
+    pass: vcap
+    database: postgres
+    restore_bin: pg_restore
+    dump_bin: pg_dump
 use_warden: false


### PR DESCRIPTION
change the example configuration files

Won't impact any deployment, no yeti-test needed.
Unit-test passed for postgresql_node.yml (warden/non-warden) that would be used for CI test.
