### PR TITLE
Use HTTP Git URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "govendor"]
 	path = govendor
-	url = git://github.com/cloudfoundry/govendor.git
+	url = http://github.com/cloudfoundry/govendor.git


### PR DESCRIPTION
For the sake of those of us stuck behind a corporate proxy server, please use http: URLs rather than git: URLs.
